### PR TITLE
Fix the case when image is actually loaded but image node has not updated yet, second check in next cycle of event loop fixes that

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,8 +16,10 @@ function loadSingleImage(image: HTMLImageElement): ImagePromise {
 			// If the browser can determine the naturalWidth the image is already loaded successfully
 			resolve(image);
 		} else if (image.complete) {
-			// If the image is complete but the naturalWidth is 0px it is probably broken
-			reject(image);
+			// If the image is complete but the naturalWidth is 0px it is probably broken,
+			// but in some cases it is actually loaded but image node has not updated
+			// yet so let's check again in next cycle of browser event loop
+			setTimeout(fulfill, 0);
 		} else {
 			image.addEventListener('load', fulfill);
 			image.addEventListener('error', fulfill);


### PR DESCRIPTION
This fixes image promise returning error instead of success in mobile safari